### PR TITLE
more verbose json errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -821,6 +822,12 @@ func handleClientError(err error) {
 		default:
 			fmt.Fprintln(os.Stderr, err.Error())
 		}
+	case *json.UnmarshalTypeError:
+		s := fmt.Sprintf("UnmarshalTypeError: Value[%s] Type[%v]\n", err.Value, err.Type)
+		fmt.Fprint(os.Stderr, s)
+	case *json.InvalidUnmarshalError:
+		s := fmt.Sprintf("InvalidUnmarshalError: Type[%v]\n", err.Type)
+		fmt.Fprint(os.Stderr, s)
 	default:
 		fmt.Fprintln(os.Stderr, err.Error())
 	}


### PR DESCRIPTION
While debugging json parse errors , I found the following snippet useful.
It adds the name and type of fields that error.