### PR TITLE
always print colors, add --no-colors flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,8 +136,23 @@ func main() {
 			Usage:  "Enable debug logging",
 			EnvVar: "CIRCLE_DEBUG",
 		},
+		cli.StringFlag{
+			Name:  "color",
+			Usage: "Suppress or forcely print highlighting, value can be: auto, always, never",
+			Value: "auto",
+		},
 	}
 	app.Before = func(c *cli.Context) (err error) {
+		if c.String("color") == "always" {
+			color.NoColor = false
+		} else if c.String("color") == "never" {
+			color.NoColor = true
+		} else if c.String("color") != "auto" {
+			return fmt.Errorf(
+				"unexpected --color value: %q", c.String("color"),
+			)
+		}
+
 		baseURL, err := url.Parse(c.String("host") + "/api/v1/")
 		if err != nil {
 			return err


### PR DESCRIPTION
Package fatih/color detects when stdout is not terminal and disables colorizing.

Now we can use circleci-cli with `watch` tool like as following:

```bash
watch -c -n0.1 circleci-cli --token-file ~/.config/circleci/token show
```

![example](https://i.imgur.com/OLFebIG.gif)

If user want to disable colors then he will need to pass `--no-colors` flag.